### PR TITLE
Don't show entities hidden in Home Assistant

### DIFF
--- a/extension/plugins/home-assistant/api.js
+++ b/extension/plugins/home-assistant/api.js
@@ -417,7 +417,7 @@ export const HomeAssistantBridge =  GObject.registerClass({
             "template": '{\
             {% for area in areas() %} \
                 "{{area}}": {"name":"{{area_name(area)}}", "entities":[\
-                {% for entity in area_entities(area) %}\
+                {% for entity in area_entities(area) if not is_hidden_entity(entity) %}\
                     "{{ entity }}" \
                     {{ "," if not loop.last }}\
                 {% endfor %} ]}\


### PR DESCRIPTION
If an entity in Home Assistant is marked as hidden, I would expect it to not be shown in this extension. However, the extension shows every entity, including hidden ones. This PR fixes that by adding a check in the getAreas function for if each entity is hidden or not.