### PR TITLE
Only auto-expand submenu when "remember opened submenu" is enabled

### DIFF
--- a/extension/smarthome-panelmenu.js
+++ b/extension/smarthome-panelmenu.js
@@ -3497,12 +3497,14 @@ export const SmartHomePanelMenu = GObject.registerClass({
         let selectedGroup = this._menuSelected['group'];
         let selectedDevice = this._menuSelected['device'];
 
-        this._openMenu = this._menuObjects['groups']['object'].menu;
-        if (selectedGroup && selectedGroup !== '_all_') {
-            this._openMenu = this._menuObjects['devices']['object'].menu;
-        }
-        if (selectedDevice && this._menuObjects['controls']['object']) {
-            this._openMenu = this._menuObjects['controls']['object'].menu;
+        if (this._rememberOpenedSubmenu) {
+            this._openMenu = this._menuObjects['groups']['object'].menu;
+            if (selectedGroup && selectedGroup !== '_all_') {
+                this._openMenu = this._menuObjects['devices']['object'].menu;
+            }
+            if (selectedDevice && this._menuObjects['controls']['object']) {
+                this._openMenu = this._menuObjects['controls']['object'].menu;
+            }
         }
 
         this.refreshMenu();


### PR DESCRIPTION
selectMenu() unconditionally set _openMenu to the color picker (Color & Temperature) submenu whenever a device was selected, causing it to auto-expand on menu open regardless of the "remember opened submenu" setting. Gate it behind that setting, consistent with the other open-state-changed handlers in the file.


Claude-Session: https://claude.ai/code/session_01TYZCVMbvvDw1vpW4yd2nnx